### PR TITLE
Update deal.II

### DIFF
--- a/include/hyper.deal/base/memory_consumption.h
+++ b/include/hyper.deal/base/memory_consumption.h
@@ -315,11 +315,11 @@ namespace hyperdeal
       dealii::Utilities::System::get_memory_stats(stats);
 
       list.emplace_back(label,
-                        std::array<double, 4>{static_cast<double>(stats.VmPeak),
-                                              static_cast<double>(stats.VmSize),
-                                              static_cast<double>(stats.VmHWM),
-                                              static_cast<double>(
-                                                stats.VmRSS)});
+                        std::array<double, 4>{
+                          {static_cast<double>(stats.VmPeak),
+                           static_cast<double>(stats.VmSize),
+                           static_cast<double>(stats.VmHWM),
+                           static_cast<double>(stats.VmRSS)}});
 
       MPI_Barrier(comm);
     }
@@ -376,9 +376,9 @@ namespace hyperdeal
         collection.size());
 
       for (unsigned int i = 0; i < collection.size(); i++)
-        collection_[i] = {collection[i].first,
-                          std::array<double, 1>{
-                            static_cast<double>(collection[i].second)}};
+        collection_[i] = std::pair<std::string, std::array<double, 1>>{
+          collection[i].first,
+          std::array<double, 1>{{static_cast<double>(collection[i].second)}}};
 
       internal::print(
         stream, comm, collection_, {"Memory consumption [Byte]"}, 0);

--- a/include/hyper.deal/base/timers.h
+++ b/include/hyper.deal/base/timers.h
@@ -137,8 +137,8 @@ namespace hyperdeal
         {
           list.emplace_back(time.first,
                             std::array<double, 1>{
-                              timers[time.second].get_accumulated_time() /
-                              1000000});
+                              {timers[time.second].get_accumulated_time() /
+                               1000000}});
           list_count.emplace_back(time.first,
                                   timers[time.second].get_counter());
 

--- a/include/hyper.deal/matrix_free/matrix_free.cc
+++ b/include/hyper.deal/matrix_free/matrix_free.cc
@@ -236,10 +236,12 @@ namespace hyperdeal
 
 
 
-      auto cell_to_gid =
+      const auto cell_to_gid =
         [&](const typename dealii::DoFHandler<dim, dim>::cell_iterator &cell) {
-          dealii::DoFAccessor<dim, dealii::DoFHandler<dim>, true> a(
-            &triangulation, cell->level(), cell->index(), &dof_handler_1);
+          dealii::DoFAccessor<dim, dim, dim, true> a(&triangulation,
+                                                     cell->level(),
+                                                     cell->index(),
+                                                     &dof_handler_1);
 
           std::vector<dealii::types::global_dof_index> indices(1);
           a.get_dof_indices(indices);

--- a/include/hyper.deal/matrix_free/vector_partitioner.h
+++ b/include/hyper.deal/matrix_free/vector_partitioner.h
@@ -704,11 +704,11 @@ namespace hyperdeal
                   AssertThrow(ptr2 != maps_ghost.end(),
                               dealii::ExcMessage("Entry not found!"));
 
-                  std::array<LocalDoFType, 5> v{ptr1->second.first,
-                                                ptr1->second.second,
-                                                face,
-                                                ptr2->second.first,
-                                                ptr2->second.second};
+                  std::array<LocalDoFType, 5> v{{ptr1->second.first,
+                                                 ptr1->second.second,
+                                                 face,
+                                                 ptr2->second.first,
+                                                 ptr2->second.second}};
 
                   ghost_list_shared_precomp.push_back(v);
 
@@ -734,11 +734,11 @@ namespace hyperdeal
                       auto & /*request_buffer*/) {
                     for (unsigned int i = 0; i < buffer_recv.size(); i += 5)
                       maps_ghost_inverse_precomp.push_back(
-                        {buffer_recv[i],
-                         buffer_recv[i + 1],
-                         buffer_recv[i + 2],
-                         buffer_recv[i + 3],
-                         buffer_recv[i + 4]});
+                        {{buffer_recv[i],
+                          buffer_recv[i + 1],
+                          buffer_recv[i + 2],
+                          buffer_recv[i + 3],
+                          buffer_recv[i + 4]}});
                   });
             dealii::Utilities::MPI::ConsensusAlgorithms::Selector<LocalDoFType,
                                                                   LocalDoFType>(
@@ -923,9 +923,9 @@ namespace hyperdeal
                                                    " not found!"));
 
                     temp[i] = std::array<unsigned int, 3>{
-                      ptr->second.first,
-                      (unsigned int)ptr->second.second,
-                      face_no};
+                      {ptr->second.first,
+                       (unsigned int)ptr->second.second,
+                       face_no}};
                   }
                 return temp;
               }();
@@ -1010,9 +1010,8 @@ namespace hyperdeal
                 AssertThrow(sm_rank == t[3],
                             dealii::StandardExceptions::ExcNotImplemented());
                 temp_[t[0]].emplace_back(
-                  std::array<dealii::types::global_dof_index, 3>{t[1],
-                                                                 t[2],
-                                                                 t[4]});
+                  std::array<dealii::types::global_dof_index, 3>{
+                    {t[1], t[2], t[4]}});
               }
 
 
@@ -1053,9 +1052,8 @@ namespace hyperdeal
                 AssertThrow(sm_rank == t[0],
                             dealii::StandardExceptions::ExcNotImplemented());
                 temp_[t[3]].emplace_back(
-                  std::array<dealii::types::global_dof_index, 3>{t[4],
-                                                                 t[2],
-                                                                 t[1]});
+                  std::array<dealii::types::global_dof_index, 3>{
+                    {t[4], t[2], t[1]}});
               }
 
 

--- a/include/hyper.deal/numerics/vector_tools.h
+++ b/include/hyper.deal/numerics/vector_tools.h
@@ -180,7 +180,7 @@ namespace hyperdeal
       FEEvaluation<dim_x, dim_v, degree, n_points, Number, VectorizedArrayType>
         phi(matrix_free, dof_no_x, dof_no_v, quad_no_x, quad_no_v);
 
-      std::array<Number, 2> result{0.0, 0.0};
+      std::array<Number, 2> result{{0.0, 0.0}};
 
       int dummy;
 


### PR DESCRIPTION
with the following relevant changes:
- the compiler flag `-Wmissing-braces` has been enabled per default, requiring to write two curly brackets `{{}}` for the instantiation of `std::array`
- the template parameter `DoFHandlerType` has been removed from many places (also from `dealii::DoFAccessor`)