### PR TITLE
Zero out FEEvaluationBase::data during construction

### DIFF
--- a/include/hyper.deal/matrix_free/fe_evaluation_base.h
+++ b/include/hyper.deal/matrix_free/fe_evaluation_base.h
@@ -145,7 +145,7 @@ namespace hyperdeal
     , matrix_free_x(matrix_free.get_matrix_free_x())
     , matrix_free_v(matrix_free.get_matrix_free_v())
   {
-    this->data.resize_fast(static_dofs);
+    this->data.resize(static_dofs);
   }
 
 

--- a/tests/tests_mf.h
+++ b/tests/tests_mf.h
@@ -193,8 +193,9 @@ namespace hyperdeal
             quads.push_back(dealii::QGaussLobatto<1>(n_points_x));
           else
             quads.push_back(dealii::QGauss<1>(n_points_x));
-          quads.push_back(dealii::QGauss<1>(degree_x + 1)),
-            quads.push_back(dealii::QGaussLobatto<1>(degree_x + 1));
+
+          quads.push_back(dealii::QGauss<1>(degree_x + 1));
+          quads.push_back(dealii::QGaussLobatto<1>(degree_x + 1));
 
           matrix_free_x.reinit(
             mapping_x, dof_handlers, constraints, quads, additional_data);


### PR DESCRIPTION
Test `vector_tools/vector_tools_01.mpirun=24.debug` has been failing for me locally with

```
mpiexec noticed that process rank 19 with PID 0 on node node36 exited on signal 8 (Floating point exception).
```

After lengthy debugging (and ending up in `EvaluatorTensorProduct::apply`!?), I was able to pinpoint down the problem to `AlignVector::resize_fast()`. This per-se is not a problem but during `read_dof_values` we don't zero out lanes which are not corresponding to any cells (leaving certain array entries uninitialized). We might change this some day to be consistent with deal.II.

Initializing the `FEEvaluationBase::data` per default should be not a problem since we normally initialize `FEEvalutation`/`FEFaceEvalutation` outside of the cell/face loop.