### PR TITLE
Print deal.II git information

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,13 @@ ADD_CUSTOM_TARGET(release
 
 DEAL_II_INITIALIZE_CACHED_VARIABLES()
 
+DEAL_II_QUERY_GIT_INFORMATION()
+
+MESSAGE("-- deal.II-version ")
+MESSAGE("-- deal.II-branch: " ${DEAL_II_GIT_BRANCH})
+MESSAGE("-- deal.II-hash:   " ${DEAL_II_GIT_REVISION})
+MESSAGE("")
+
 DEAL_II_SETUP_TARGET(hyperdeal)
 
 # load macros and scripts


### PR DESCRIPTION
During configuration the following output will appear:
```
-- deal.II-version 
-- deal.II-branch: master
-- deal.II-hash:   cd6047cf8a54efac208a38d4d45fa9d407ca876d

```

This PR enables us to track which deal.II version works with which hyper.deal version.

@kkormann I think you might like this!