### PR TITLE
Add (git) revisioning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ DEAL_II_INITIALIZE_CACHED_VARIABLES()
 SET( TARGET_SRC hyperdeal.cc )
 
 # Set the include directory and the name of the project
-INCLUDE_DIRECTORIES(include)
+INCLUDE_DIRECTORIES(include ${CMAKE_CURRENT_BINARY_DIR}/include)
 
 PROJECT(hyperdeal)
 
@@ -58,12 +58,27 @@ ADD_CUSTOM_TARGET(release
 
 DEAL_II_INITIALIZE_CACHED_VARIABLES()
 
-DEAL_II_QUERY_GIT_INFORMATION()
+DEAL_II_QUERY_GIT_INFORMATION(HYPER_DEAL)
+MESSAGE("--")
 
-MESSAGE("-- deal.II-version ")
-MESSAGE("-- deal.II-branch: " ${DEAL_II_GIT_BRANCH})
-MESSAGE("-- deal.II-hash:   " ${DEAL_II_GIT_REVISION})
-MESSAGE("")
+MESSAGE("-- hyper.deal-version ")
+MESSAGE("-- hyper.deal-branch: " ${HYPER_DEAL_GIT_BRANCH})
+MESSAGE("-- hyper.deal-hash:   " ${HYPER_DEAL_GIT_REVISION})
+MESSAGE("--")
+
+MESSAGE("-- deal.II-version    ")
+MESSAGE("-- deal.II-branch:    " ${DEAL_II_GIT_BRANCH})
+MESSAGE("-- deal.II-hash:      " ${DEAL_II_GIT_REVISION})
+MESSAGE("--")
+
+cmake_policy(SET CMP0053 OLD)
+SET(HYPER_DEAL_GIT_BRANCH "@HYPER_DEAL_GIT_BRANCH@")
+SET(HYPER_DEAL_GIT_REVISION "@HYPER_DEAL_GIT_REVISION@")
+
+CONFIGURE_FILE(
+  ${CMAKE_CURRENT_SOURCE_DIR}/include/hyper.deal/base/revision.h.in
+  ${CMAKE_CURRENT_BINARY_DIR}/include/hyper.deal/base/revision.h
+  )
 
 DEAL_II_SETUP_TARGET(hyperdeal)
 

--- a/doc/news/changes/20200910Munch
+++ b/doc/news/changes/20200910Munch
@@ -1,0 +1,6 @@
+New: The git information can now be queried either via the HYPER_DEAL_GIT_BRANCH
+and HYPER_DEAL_GIT_REVISION. As a utility function, hyperdeal::Utilities::print_version
+has been added, which prints formatted the git information both of hyper.deal
+and deal.II.
+<br>
+(Peter Munch, 2020/09/10)

--- a/examples/advection/advection.cc
+++ b/examples/advection/advection.cc
@@ -16,7 +16,6 @@
 #include <hyper.deal/base/config.h>
 
 #include <deal.II/base/mpi.h>
-#include <deal.II/base/revision.h>
 
 #include <hyper.deal/base/dynamic_convergence_table.h>
 #include <hyper.deal/base/mpi.h>
@@ -227,9 +226,14 @@ main(int argc, char **argv)
     {
       dealii::Utilities::MPI::MPI_InitFinalize mpi(argc, argv, 1);
 
+      dealii::ConditionalOStream pcout(
+        std::cout, dealii::Utilities::MPI::this_mpi_process(comm) == 0);
+
+      hyperdeal::Utilities::print_version(pcout);
+
       if (argc == 1)
         {
-          if (dealii::Utilities::MPI::this_mpi_process(comm) == 0)
+          if (pcout.is_active())
             printf("ERROR: No .json parameter files has been provided!\n");
 
           return 1;
@@ -237,15 +241,10 @@ main(int argc, char **argv)
       else if (argc == 3 && (std::string(argv[1]) == "--help" ||
                              std::string(argv[1]) == "--help-detail"))
         {
-          if (dealii::Utilities::MPI::this_mpi_process(comm) == 0)
+          if (pcout.is_active())
             print_parameters(std::string(argv[1]) == "--help-detail", argv[2]);
           return 0;
         }
-
-      if (dealii::Utilities::MPI::this_mpi_process(comm) == 0)
-        printf("deal.II git version %s on branch %s\n\n",
-               DEAL_II_GIT_SHORTREV,
-               DEAL_II_GIT_BRANCH);
 
       dealii::deallog.depth_console(0);
 

--- a/include/hyper.deal/base/revision.h.in
+++ b/include/hyper.deal/base/revision.h.in
@@ -1,0 +1,34 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2020 by the hyper.deal authors
+//
+// This file is part of the hyper.deal library.
+//
+// The hyper.deal library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 3.0 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.MD at
+// the top level directory of hyper.deal.
+//
+// ---------------------------------------------------------------------
+
+#ifndef hyperdeal_revision_h
+#define hyperdeal_revision_h
+
+/**
+ * Name of the local git branch of the source directory.
+ */
+#define HYPER_DEAL_GIT_BRANCH "@HYPER_DEAL_GIT_BRANCH@"
+
+/**
+ * Full sha1 revision of the current git HEAD.
+ */
+#define HYPER_DEAL_GIT_REVISION "@HYPER_DEAL_GIT_REVISION@"
+
+/**
+ * Short sha1 revision of the current git HEAD.
+ */
+#define HYPER_DEAL_GIT_SHORTREV "@HYPER_DEAL_GIT_SHORTREV@"
+
+#endif

--- a/include/hyper.deal/base/utilities.h
+++ b/include/hyper.deal/base/utilities.h
@@ -47,6 +47,13 @@ namespace hyperdeal
      */
     std::pair<unsigned int, unsigned int>
     decompose(const unsigned int &number);
+
+    /**
+     * Print hyper.deal and deal.II git version information.
+     */
+    template <typename StreamType>
+    void
+    print_version(const StreamType &stream);
   } // namespace Utilities
 } // namespace hyperdeal
 

--- a/source/base/utilities.cc
+++ b/source/base/utilities.cc
@@ -13,8 +13,11 @@
 //
 // ---------------------------------------------------------------------
 
+#include <deal.II/base/conditional_ostream.h>
 #include <deal.II/base/mpi.templates.h>
+#include <deal.II/base/revision.h>
 
+#include <hyper.deal/base/revision.h>
 #include <hyper.deal/base/utilities.h>
 #include <immintrin.h>
 
@@ -62,6 +65,27 @@ namespace hyperdeal
 
       return possible_solutions.front();
     }
+
+
+
+    template <typename StreamType>
+    void
+    print_version(const StreamType &stream)
+    {
+      stream << "-- hyper.deal-version " << std::endl;
+      stream << "-- hyper.deal-branch: " << HYPER_DEAL_GIT_BRANCH << std::endl;
+      stream << "-- hyper.deal-hash:   " << HYPER_DEAL_GIT_REVISION
+             << std::endl;
+      stream << "--                    " << std::endl;
+      stream << "-- deal.II-version    " << std::endl;
+      stream << "-- deal.II-branch:    " << DEAL_II_GIT_BRANCH << std::endl;
+      stream << "-- deal.II-hash:      " << DEAL_II_GIT_REVISION << std::endl;
+      stream << "--                    " << std::endl;
+    }
+
+    // template instantiations
+    template void
+    print_version(const dealii::ConditionalOStream &stream);
 
   } // namespace Utilities
 } // namespace hyperdeal


### PR DESCRIPTION
Follow-up to #49 but now for hyper.deal.

The output new looks like this:
```
-- hyper.deal-version 
-- hyper.deal-branch: git_info_hyperdeal
-- hyper.deal-hash:   be66c26dc45854942e907525ba62171a42bb885a
--
-- deal.II-version    
-- deal.II-branch:    master
-- deal.II-hash:      cd6047cf8a54efac208a38d4d45fa9d407ca876d
--
```

The same output can be generated within the actual program by calling `hyperdeal::Utilities::print_version(stream)`.