### PR TITLE
Fix quad-DoF mapping issue for colocation setup

### DIFF
--- a/include/hyper.deal/matrix_free/shape_info.h
+++ b/include/hyper.deal/matrix_free/shape_info.h
@@ -104,7 +104,7 @@ namespace hyperdeal
               dealii::Utilities::pow(points, dim_v - 1);
             const auto dofs_per_x_cell = dealii::Utilities::pow(points, dim_x);
 
-            if (direction == 1)
+            if (direction == 1 && dim_x == 3)
               {
                 // Here the faces are in X space, so their DoF indices are
                 // located sequentially. Offset is the number of DoFs in
@@ -117,7 +117,7 @@ namespace hyperdeal
                         face_to_cell_local.at(offset + i + j * points);
                 face_to_cell_index_nodal[face] = tmp;
               }
-            else if (direction == 4)
+            else if (direction == 4 && dim_v == 3)
               {
                 // Here the faces are in V space, so for each face its DoFs are
                 // separated by `dofs_per_cell` other DoFs. Offset is the number

--- a/include/hyper.deal/matrix_free/shape_info.h
+++ b/include/hyper.deal/matrix_free/shape_info.h
@@ -92,6 +92,37 @@ namespace hyperdeal
                   (s == 0 ? 0 : (points - 1)) * std::pow(points, d) + j;
           }
 
+        // Patch quad order for directions 1 and 4
+        std::vector<unsigned int> tmp(dofs_per_component_on_face);
+        for (const auto face : dealii::GeometryInfo<dim>::face_indices()) {
+          const auto direction = face / 2;
+          const auto& face_to_cell_local = face_to_cell_index_nodal[face];
+
+          const auto dofs_per_x_face = dealii::Utilities::pow(points, dim_x - 1);
+          const auto dofs_per_v_face = dealii::Utilities::pow(points, dim_v - 1);
+          const auto dofs_per_x_cell = dealii::Utilities::pow(points, dim_x);
+
+          if (direction == 1) {
+            // Here the faces are in X space, so their DoF indices are located sequentially.
+            // Offset is the number of DoFs in preceding faces.
+            for (auto offset = 0u; offset < dofs_per_face; offset += dofs_per_x_face)
+              for (auto j = 0u; j < dofs_per_x_face / points; ++j)
+                for (auto i = 0u; i < points; ++i)
+                  tmp.at(offset + j + i*points) = face_to_cell_local.at(offset + i + j*points);
+            face_to_cell_index_nodal[face] = tmp;
+          }
+          else if (direction == 4) {
+            // Here the faces are in V space, so for each face its DoFs are separated by
+            // `dofs_per_cell` other DoFs.
+            // Offset is the number of DoFs in preceding faces.
+            for (auto offset = 0u; offset < dofs_per_x_cell; ++offset)
+              for (auto j = 0u; j < dofs_per_v_face / points; ++j)
+                for (auto i = 0u; i < points; ++i)
+                  tmp.at(offset + dofs_per_x_cell*(j + i*points)) = face_to_cell_local.at(offset + dofs_per_x_cell*(i + j*points));
+            face_to_cell_index_nodal[face] = tmp;
+          }
+        }
+
         // clang-format off
         if (dim_x == 3 || dim_v == 3)
           {


### PR DESCRIPTION
## Problem statement

hyper.deal uses the DoF numbering scheme different from deal.II's one: it doesn't use the weird Y axis swap. It does make the code simpler, but leads to erroneous results when using hyper.deal together with deal.II infrastructure.

An example: variable transport velocity depending on the coordinate values. If the velocity changes in the space we're doing advection in (essentialy it's `df/dt + v*df/dr + A(r, v, t)*df/dv = 0`), then cell fluxes are mixed up (see [my question here](https://github.com/hyperdeal/hyperdeal/discussions/97)). It isn't the case when solving Vlasov's equation with only electric field (transport velocity is always constant in velocity space, `A = A(r, t)`, so the "vlasov-poisson" example isn't affected), but it does matter when working with magnetic field (here `A = q/m*(v x B(r)) = A(r, v, t)`). Here `dealii::FEFaceEvaluation::quadrature_point` (and `hyperdeal::FEFaceEvaluation::get_quadrature_point` which uses the former) will return wrong coordinates to calculate transport velocity for, producing wrong fluxes. The same issue may occur if a magnetic field DoF vector is taken from a purely deal.II-based solver.

## Provided solution

I believe that it's important to be able to use deal.II facilities (e.g. to plug in a 3-D Maxwell solver) without additional DoF renumbering middleware and quadpoint coordinate calculation rewrite. But to make the code more readable (it was extremely hard for me to unravel how indexing loops for quad-DoF LUT in deal.II were made) I just added a renumbering loop to simply implement Y axis swap as described in the docs.

## ToDo

Unfortunately, for now I've implemented only the simplest colocation case, where only a lookup table is used. Since I'm not that experienced with deal.II's internals, I haven't figured out how quad-DoF mapping is done in the Gauss-Legendre case.

Obviously, a lot of tests which check DoF vectors would need updating.